### PR TITLE
fix: ELECTRON_RENDERER_URL is incorrect

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { spawn } from 'child_process'
 import { createServer as ViteCreateServer, build as viteBuild, createLogger } from 'vite'
 import colors from 'picocolors'
 import { InlineConfig, resolveConfig } from './config'
-import { ensureElectronEntryFile, getElectronPath } from './utils'
+import { ensureElectronEntryFile, getElectronPath, resolveHostname } from './utils'
 
 export async function createServer(inlineConfig: InlineConfig = {}): Promise<void> {
   const config = await resolveConfig(inlineConfig, 'serve', 'development')
@@ -39,7 +39,7 @@ export async function createServer(inlineConfig: InlineConfig = {}): Promise<voi
       const conf = server.config.server
 
       const protocol = conf.https ? 'https:' : 'http:'
-      const host = conf.host || 'localhost'
+      const host = resolveHostname(conf.host)
       const port = conf.port
       process.env.ELECTRON_RENDERER_URL = `${protocol}//${host}:${port}`
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,3 +37,9 @@ export function getElectronPath(): string {
     throw new Error('Electron uninstall')
   }
 }
+
+export const wildcardHosts = new Set(['0.0.0.0', '::', '0000:0000:0000:0000:0000:0000:0000:0000'])
+
+export function resolveHostname(optionsHost: string | boolean | undefined): string {
+  return typeof optionsHost === 'string' && !wildcardHosts.has(optionsHost) ? optionsHost : 'localhost'
+}


### PR DESCRIPTION

### Description

When set `rendererViteConfig - host` is `true`, `ELECTRON_RENDERER_URL` will be `${protocol}//true:${port}`, but the correct value should be `${protocol}//localhost:${port}`

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ X ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
