### PR TITLE
修复：preload config是function时报错；特性：`main` 更新后 Electron 重启和 `preload` 更新后重新挂载

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ English | [简体中文](./README.zh-CN.md)
 - 📃Main process, renderer process and preload script Vite configuration combined into one file
 - 📦Preset optimal build configuration
 - 🚀HMR for renderer processes
+- 🌈Restart Electron after `main` or `preload` update
 
 ## Usage
 
@@ -162,7 +163,7 @@ See [vitejs.dev](https://vitejs.dev/config)
 
 ### Config presets
 
-#### Build options for `main`:
+#### Build options for `main`
 
 - **outDir**: `out\main`(relative to project root)
 - **target**: `node*`, automatically match node target of `Electron`. For example, the node target of Electron 17 is `node16.13`
@@ -170,7 +171,7 @@ See [vitejs.dev](https://vitejs.dev/config)
 - **lib.formats**: `cjs`
 - **rollupOptions.external**: `electron` and all builtin modules
 
-#### Build options for `preload`:
+#### Build options for `preload`
 
 - **outDir**: `out\preload`(relative to project root)
 - **target**: the same as `main`
@@ -178,7 +179,7 @@ See [vitejs.dev](https://vitejs.dev/config)
 - **lib.formats**: `cjs`
 - **rollupOptions.external**: the same as `main`
 
-#### Build options for `renderer`:
+#### Build options for `renderer`
 
 - **root**: `src\renderer`(relative to project root)
 - **outDir**: `out\renderer`(relative to project root)
@@ -233,6 +234,28 @@ export default {
     }
   }
 }
+```
+
+#### How to restart Electron after `main` or `preload` update？
+
+```js
+export default defineConfig({
+    main: ({ command }) => ({
+        build: {
+            watch: command === 'serve' ? {} : undefined,
+            // ...
+        },
+    }),
+    preload: ({ command }) => ({
+        build: {
+            watch: command === 'serve' ? {} : undefined,
+            // ...
+        }
+    }),
+    renderer: {
+        // ...
+    }
+})
 ```
 
 ## CLI options

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,6 +18,7 @@
 - 📃 统一所有配置，合并到一个文件中
 - 📦 预设构建配置，无需关注配置
 - 🚀 支持渲染进程热更新(HMR)
+- 🌈 支持 `main` 更新后 Electron 重启和 `preload` 更新后重新挂载
 
 ## 用法
 
@@ -162,7 +163,7 @@ export default defineConfig({
 
 ### 配置预设
 
-#### `主进程`编译项预设：
+#### `主进程`编译项预设
 
 - **outDir**：`out\main`（相对于根目录）
 - **target**：`node*`，自动匹配 `Electron` 的 `node` 构建目标，如 Electron 17 为 `node16.13`
@@ -170,7 +171,7 @@ export default defineConfig({
 - **lib.formats**：`cjs`
 - **rollupOptions.external**：`electron` 和所有内置 node 模块(如果用户配置了外部模块 ID，将自动合并)
 
-#### `preload` 脚本编译项预设：
+#### `preload` 脚本编译项预设
 
 - **outDir**：`out\preload`（相对于根目录）
 - **target**：同`主进程`
@@ -178,7 +179,7 @@ export default defineConfig({
 - **lib.formats**：`cjs`
 - **rollupOptions.external**：同`主进程`
 
-#### `渲染进程`编译项预设：
+#### `渲染进程`编译项预设
 
 - **root**：`src\renderer`（相对于根目录）
 - **outDir**：`out\renderer`（相对于根目录）
@@ -187,7 +188,7 @@ export default defineConfig({
 - **polyfillModulePreload**：`false`，不需要为渲染进程 polyfill `Module Preload`
 - **rollupOptions.external**：同`主进程`
 
-#### `主进程`和 `preload` 脚本的 `define` 项设置：
+#### `主进程`和 `preload` 脚本的 `define` 项设置
 
 在 Web 开发中，Vite 会将 `'process.env.'` 替换为 `'({}).'`，这是合理和正确的。但在 nodejs 开发中，我们有时候需要使用 `process.env` ，所以 `electron-vite` 重新预设全局变量替换，恢复其使用，预设如下：
 
@@ -233,6 +234,30 @@ export default {
     }
   }
 }
+```
+
+#### 如何支持 `main` 更新后 Electron 重启和 `preload` 更新后重新挂载？
+
+在 `serve` 命令下，`main` 和 `preload` 脚本更新后，你可能想要让 Electron 重启和 `preload` 重新挂载，你可以在配置中这样做：
+
+```js
+export default defineConfig({
+    main: ({ command }) => ({
+        build: {
+            watch: command === 'serve' ? {} : undefined,
+            // ...
+        },
+    }),
+    preload: ({ command }) => ({
+        build: {
+            watch: command === 'serve' ? {} : undefined,
+            // ...
+        }
+    }),
+    renderer: {
+        // ...
+    }
+})
 ```
 
 ## 命令行选项

--- a/src/config.ts
+++ b/src/config.ts
@@ -287,7 +287,7 @@ export async function loadConfigFromFile(
     if (config.preload) {
       const preloadViteConfig = config.preload
       preloadConfig = await (typeof preloadViteConfig === 'function' ? preloadViteConfig(configEnv) : preloadViteConfig)
-      if (!isObject(preloadViteConfig)) {
+      if (!isObject(preloadConfig)) {
         throw new Error(`preload config must export or return an object`)
       }
     } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,7 +31,7 @@ export function createElectron(root?: string, logger?: Logger): ChildProcessWith
 
 export function build(config: UserConfig, closeBundle?: PluginHooks['closeBundle']): ReturnType<typeof viteBuild> {
   const watchConfig: UserConfig = {
-    // Enable watch through `electron.vite.config.{ js | ts | mjs }`
+    // Enable watch through `electron.vite.config.{js|ts|mjs|cjs}`
     // build: { watch: {} },
     plugins: [
       {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,70 +1,122 @@
-import { spawn } from 'child_process'
-import { createServer as ViteCreateServer, build as viteBuild, createLogger } from 'vite'
+import { ChildProcessWithoutNullStreams, spawn } from 'child_process'
+import {
+  createServer as ViteCreateServer,
+  build as viteBuild,
+  createLogger,
+  Logger,
+  ViteDevServer,
+  UserConfig,
+  mergeConfig
+} from 'vite'
 import colors from 'picocolors'
 import { InlineConfig, resolveConfig } from './config'
 import { ensureElectronEntryFile, getElectronPath, resolveHostname } from './utils'
+import { PluginHooks } from 'rollup'
+
+export function createElectron(root?: string, logger?: Logger): ChildProcessWithoutNullStreams {
+  ensureElectronEntryFile(root)
+  const electronPath = getElectronPath()
+  const ps = spawn(electronPath, ['.'])
+
+  ps.stdout.on('data', chunk => {
+    chunk.toString().trim() && logger && logger.info(chunk.toString())
+  })
+  ps.stderr.on('data', chunk => {
+    chunk.toString().trim() && logger && logger.error(chunk.toString())
+  })
+  ps.on('close', process.exit)
+
+  return ps
+}
+
+export function build(config: UserConfig, closeBundle?: PluginHooks['closeBundle']): ReturnType<typeof viteBuild> {
+  const watchConfig: UserConfig = {
+    // Enable watch through `electron.vite.config.{ js | ts | mjs }`
+    // build: { watch: {} },
+    plugins: [
+      {
+        name: 'vite:electron-serve-build',
+        closeBundle
+      }
+    ]
+  }
+
+  return viteBuild(mergeConfig(watchConfig, config))
+}
+
+export async function createRenderServer(config: UserConfig): Promise<ViteDevServer> {
+  const server = await ViteCreateServer(config)
+
+  if (!server.httpServer) {
+    throw new Error('HTTP server not available')
+  }
+
+  await server.listen()
+
+  const conf = server.config.server
+  const protocol = conf.https ? 'https:' : 'http:'
+  const host = resolveHostname(conf.host)
+  const port = conf.port
+  process.env.ELECTRON_RENDERER_URL = `${protocol}//${host}:${port}`
+
+  const slogger = server.config.logger
+
+  slogger.info(colors.green(`dev server running for the electron renderer process at:\n`), {
+    clear: !slogger.hasWarned
+  })
+
+  server.printUrls()
+
+  return server
+}
 
 export async function createServer(inlineConfig: InlineConfig = {}): Promise<void> {
   const config = await resolveConfig(inlineConfig, 'serve', 'development')
-  if (config.config) {
-    const logger = createLogger(inlineConfig.logLevel)
+  const { main, preload, renderer } = config.config || {}
+  const logger = createLogger(inlineConfig.logLevel)
 
-    const mainViteConfig = config.config?.main
-    if (mainViteConfig) {
-      await viteBuild(mainViteConfig)
+  let server: ViteDevServer | undefined
+  let ps: ChildProcessWithoutNullStreams | undefined
 
+  if (main) {
+    await build(main, () => {
       logger.info(colors.green(`\nbuild the electron main process successfully`))
-    }
 
-    const preloadViteConfig = config.config?.preload
-    if (preloadViteConfig) {
-      logger.info(colors.gray(`\n-----\n`))
-      await viteBuild(preloadViteConfig)
+      if (ps) {
+        logger.info(colors.green(`\nwaiting for electron to exit...`))
 
-      logger.info(colors.green(`\nbuild the electron preload files successfully`))
-    }
+        ps.removeAllListeners()
+        ps.kill()
+        ps = createElectron(inlineConfig.root, logger)
 
-    const rendererViteConfig = config.config?.renderer
-    if (rendererViteConfig) {
-      logger.info(colors.gray(`\n-----\n`))
-
-      const server = await ViteCreateServer(rendererViteConfig)
-
-      if (!server.httpServer) {
-        throw new Error('HTTP server not available')
+        logger.info(colors.green(`\n🚀 restart electron app...`))
       }
-
-      await server.listen()
-
-      const conf = server.config.server
-
-      const protocol = conf.https ? 'https:' : 'http:'
-      const host = resolveHostname(conf.host)
-      const port = conf.port
-      process.env.ELECTRON_RENDERER_URL = `${protocol}//${host}:${port}`
-
-      const slogger = server.config.logger
-
-      slogger.info(colors.green(`dev server running for the electron renderer process at:\n`), {
-        clear: !slogger.hasWarned
-      })
-
-      server.printUrls()
-    }
-
-    ensureElectronEntryFile(inlineConfig.root)
-
-    const electronPath = getElectronPath()
-
-    const ps = spawn(electronPath, ['.'])
-    ps.stdout.on('data', chunk => {
-      chunk.toString().trim() && logger.info(chunk.toString())
     })
-    ps.stderr.on('data', chunk => {
-      chunk.toString().trim() && logger.error(chunk.toString())
-    })
-    ps.on('close', process.exit)
-
-    logger.info(colors.green(`\nstart electron app...`))
   }
+
+  if (preload) {
+    logger.info(colors.gray(`\n-----\n`))
+
+    await build(preload, () => {
+      logger.info(colors.green(`\nbuild the electron preload files successfully`))
+
+      if (server) {
+        logger.info(colors.green(`\nwaiting for render page to reload...`))
+
+        server.ws.send({ type: 'full-reload' })
+
+        logger.info(colors.green(`\nreload render page successfully`))
+      }
+    })
+  }
+
+  if (renderer) {
+    logger.info(colors.gray(`\n-----\n`))
+
+    server = await createRenderServer(renderer)
+  }
+
+  ps = createElectron(inlineConfig.root, logger)
+
+  logger.info(colors.green(`\n🚀 start electron app...`))
 }


### PR DESCRIPTION
fix: preload config will error when preload config is a function.
feat: restart Electron after `main` update and reload render page after `preload` update .

修复：preload config是function时报错。
特性：main 更新后 Electron 重启和 preload 更新后重新挂载。

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

#### 修复

- 错误代码：`src/config.ts`文件内`290`行代码`if (!isObject(preloadViteConfig)) {`。
- 错误描述：此bug会导致`electron.vite.config.{js|ts|mjs|cjs}`配置文件内的`preload`属性定义为`function`时，报错`Error: preload config must export or return an object`。
- 修改后代码：`if (!isObject(preloadConfig)) {`。

#### 特性

- 特性描述：`main` 更新后 Electron 重启和 `preload` 更新后重新挂载。
- 修改文件：`src/server.ts`。
- 使用方式：

  ```js
  // file: electron.vite.config.{js|ts|mjs|cjs}
  export default defineConfig({
      main: ({ command }) => ({
          build: {
              watch: command === 'serve' ? {} : undefined,
              // ...
          },
      }),
      preload: ({ command }) => ({
          build: {
              watch: command === 'serve' ? {} : undefined,
              // ...
          }
      }),
      renderer: {
          // ...
      }
  })
  ```

- 已修改`README`文档

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

#### 为什么要提供「`main` 更新后 Electron 重启和 `preload` 更新后重新挂载」的特性？

我注意到 [主进程不支持热更新么？](https://github.com/alex8088/electron-vite/issues/7) 中的讨论，引用其中的一段话：

> electron主进程的热更新实际为node模块更替，也有一些关于node的热更新方案，但实际应用很少也不成熟。在electron中也有一些社区模块通过检测并重启electron进程方式达到目的，但这不是热更新的概念，这种方式并不友好，不是很好的开发实践。electron-vite 渲染进程的热更新是基于vite下browser环境， electron-vite 没有关于主进程的热更新实现。

诚然，重启electron进程，不是热更新的概念，但我觉得这是可行的，有以下三点理由：

1. 监视 `main` 和 `preload` 的更新是一个需求，很多开发者都需要这个特性。
2. `vue-cli-plugin-electron-builder`是一个成熟的插件，也是通过重启electron进程的方式完成这个需求的，那么我们也可以这么做，将是否使用这个特性的决定权交给使用者往往更好（使用者可以通过在`electron.vite.config.{js|ts|mjs|cjs}`文件内设置`{main|preload}.build.watch`属性方便的开启或关闭这个特性）。
3. 最关键的一点是，如果增加了这个特性，那是多么的酷！

最后，我想表达下我的感谢，此仓库`electron-vite`为我在`vite`环境下开发electron提供了很大帮助，希望它变得更好，期望您考虑此功能！

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
