### PR TITLE
perf: use `require.resolve` to find electron package

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -511,8 +511,8 @@ export function externalizeDepsPlugin(options: ExternalOptions = {}): Plugin | n
 function getElectronMainVer(root: string): string {
   let mainVer = process.env.ELECTRON_MAIN_VER || ''
   if (!mainVer) {
-    const electronModulePath = path.resolve(root, 'node_modules', 'electron')
-    const pkg = path.join(electronModulePath, 'package.json')
+    const electronModulePath = require.resolve('electron')
+    const pkg = path.join(electronModulePath, '../package.json')
     if (fs.existsSync(pkg)) {
       const require = createRequire(import.meta.url)
       const version = require(pkg).version


### PR DESCRIPTION
Fixes #38

<!-- Thank you for contributing! -->

### Description

This uses the `require.resolve` API to let node find the proper location of the `electron` package no matter where it is installed, instead of trying to create the path manually.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
