### PR TITLE
fix(dev): Rephrase config error messages, fix typo 'electorn'

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -11,15 +11,15 @@ const ensureElectronEntryFile = (root = process.cwd()): void => {
   if (fs.existsSync(pkg)) {
     const main = require(pkg).main
     if (!main) {
-      throw new Error('not found an entry point to electorn app, please add main field for your package.json')
+      throw new Error('No entry point found for electron app, please add a "main" field to package.json')
     } else {
       const entryPath = path.resolve(root, main)
       if (!fs.existsSync(entryPath)) {
-        throw new Error(`not found the electorn app entry file: ${entryPath}`)
+        throw new Error(`No electron app entry file found: ${entryPath}`)
       }
     }
   } else {
-    throw new Error('no package.json')
+    throw new Error('Not found: package.json')
   }
 }
 


### PR DESCRIPTION
### Description

Rephrase configuration error messages, replace 'electorn' with 'electron'.

![image](https://user-images.githubusercontent.com/143027/229168237-be97ed56-188e-4d1f-a048-b76317bbfe9f.png)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
