### PR TITLE
Support subpath imports from externalized dependencies

### DIFF
--- a/src/plugins/externalizeDeps.ts
+++ b/src/plugins/externalizeDeps.ts
@@ -33,7 +33,7 @@ export function externalizeDepsPlugin(options: ExternalOptions = {}): Plugin | n
       const defaultConfig = {
         build: {
           rollupOptions: {
-            external: [...new Set(deps)]
+            external: [...new Set(deps.map(d => new RegExp(`^${d}\/?.*`)))]
           }
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Using an array of regular expressions for rollupOptions.external, I've fixed an issue causing subpath imports or external dependencies (e.g. import {} from 'pkg/subpath') to be bundled.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [V] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ V] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [ V] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [V] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
