### PR TITLE
append the `--no-sandbox` when running with root user

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import fs from 'node:fs'
+import os from 'node:os'
 import { createRequire } from 'node:module'
 import { type ChildProcess, spawn } from 'node:child_process'
 
@@ -121,6 +122,10 @@ export function startElectron(root: string | undefined): ChildProcess {
   const isDev = process.env.NODE_ENV_ELECTRON_VITE === 'development'
 
   const args: string[] = []
+
+  if (os.userInfo().uid == 0 && isDev) {
+    args.push(`--no-sandbox`);
+  }
 
   if (!!process.env.REMOTE_DEBUGGING_PORT && isDev) {
     args.push(`--remote-debugging-port=${process.env.REMOTE_DEBUGGING_PORT}`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The latest electron requires `--no-sandbox` argument if running with root user

### Additional context

N/A

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
