### PR TITLE
feat: Add support for passing arguments to `electron` in `dev` and `preview` modes.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,6 +96,10 @@ cli
       process.env.NO_SANDBOX = '1'
     }
 
+    if (options['--']) {
+      process.env.ELECTRON_CLI_ARGS = JSON.stringify(options['--']);
+    }
+
     if (options.entry) {
       process.env.ELECTRON_ENTRY = options.entry
     }
@@ -148,6 +152,10 @@ cli
 
     if (options.entry) {
       process.env.ELECTRON_ENTRY = options.entry
+    }
+
+    if (options['--']) {
+      process.env.ELECTRON_CLI_ARGS = JSON.stringify(options['--']);
     }
 
     try {

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -122,7 +122,7 @@ export function startElectron(root: string | undefined): ChildProcess {
 
   const isDev = process.env.NODE_ENV_ELECTRON_VITE === 'development'
 
-  const args: string[] = []
+  const args: string[] = process.env.PASSED_ARGS ? JSON.parse(process.env.ELECTRON_CLI_ARGS) : []
 
   if (!!process.env.REMOTE_DEBUGGING_PORT && isDev) {
     args.push(`--remote-debugging-port=${process.env.REMOTE_DEBUGGING_PORT}`)

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -122,7 +122,7 @@ export function startElectron(root: string | undefined): ChildProcess {
 
   const isDev = process.env.NODE_ENV_ELECTRON_VITE === 'development'
 
-  const args: string[] = process.env.PASSED_ARGS ? JSON.parse(process.env.ELECTRON_CLI_ARGS) : []
+  const args: string[] = process.env.ELECTRON_CLI_ARGS ? JSON.parse(process.env.ELECTRON_CLI_ARGS) : []
 
   if (!!process.env.REMOTE_DEBUGGING_PORT && isDev) {
     args.push(`--remote-debugging-port=${process.env.REMOTE_DEBUGGING_PORT}`)


### PR DESCRIPTION
thanks for this great module! I just started using it and it works great. there's one thing I was missing:

### Description

Add support for passing arguments to `electron` in `dev` and `preview` modes.

fixes #149

this allows us to pass custom args to the electron process that can be read directly inside electron on `process.argv`, like so:

```bash
yarn dev -- --my-custom-arg some-value
yarn start -- --my-custom-arg some-value
```

(assuming my package.json is like this:)
```json
    "start": "electron-vite preview",
    "dev": "electron-vite dev -w",
```

This is beneficial because it reduces the gap between production and development, decreasing the chance of making mistakes due to differences in the two (three) environments. and it's pretty standard for something that runs something else that `--` will pass along arguments to what it runs

### Additional context

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
