### PR TITLE
feat(plugin): Allow integrating more complex render solutions

### DIFF
--- a/src/plugins/electron.ts
+++ b/src/plugins/electron.ts
@@ -393,7 +393,7 @@ export function electronRendererVitePlugin(options?: ElectronPluginOptions): Plu
         } else {
           const targets = Array.isArray(build.target) ? build.target : [build.target]
           if (targets.some(t => !t.startsWith('chrome') && !/^es((202\d{1})|next)$/.test(t))) {
-            throw new Error('The electron vite renderer config build.target must be "chrome?" or "es?".')
+            config.logger.warn('The electron vite renderer config build.target is not "chrome?" or "es?". This could be a mistake.')
           }
         }
 


### PR DESCRIPTION
BREAKING CHANGE: changes renderer plugin to no longer error when renderer `build.target` is not  "chrome?" or "es?".

Hello Everyone!

I am currently working on an adapter for using full stack sveltekit applications in Electron, and my current plan is to use `electron-vite` coupled with the `sveltekit` vite plugin to compile the application.

I am currently accomplishing this [here](https://github.com/sailpoint-oss/electron-identitynow-starter) using what is essentially a mono repo to build one app and then importing the handler into an express server embedded inside electron and building electron.

My goal is to simplify this using `electron-vite` and have this be one dev and build command that ends in a fully functional electron application.

This error is currently blocking this implementation and feels like an unnecessary limitation of the platform.

I have converted the error thrown to a warning message that I think accomplishes the same thing in most instances.

I believe that making this change would allow similar `full-stack` style implementations for other platforms that include a server-side component and can be compiled to node servers like Next.js, etc...

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
