### PR TITLE
fix: last static import for esm shim

### DIFF
--- a/src/plugins/esm.ts
+++ b/src/plugins/esm.ts
@@ -20,8 +20,7 @@ const __dirname = __cjs_path__.dirname(__filename);
 const require = __cjs_mod__.createRequire(import.meta.url);
 `
 
-const ESMStaticImportRe =
-  /(?<=\s|^|;)import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu
+const ESMStaticImportRe = /import\s+.+?\s+from\s+['"].+?['"];(?![\s\S]*import\s+.+?\s+from\s+['"].+?['"];)/gmu
 
 interface StaticImport {
   end: number


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
PR is solving an issue that user might stuck in case if bundle contains a JSDoc comment with `import` examples. Then current RegEx is wrongly detecting the last import, and inserting `CJSShim` content right into JSDoc comment.

````js
createDeferred = dist.createDeferred = deferred;
/**
 * Default export allows use as:
 *
 * ```typescript
 import deferred from '
// -- CommonJS Shims --
import __cjs_url__ from 'node:url';
import __cjs_path__ from 'node:path';
import __cjs_mod__ from 'node:module';
const __filename = __cjs_url__.fileURLToPath(import.meta.url);
const __dirname = __cjs_path__.dirname(__filename);
const require = __cjs_mod__.createRequire(import.meta.url);
@kwsites/promise-deferred`;
 ```
 */
dist.default = deferred;
````

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I don't know much about bundling edge cases that might be affected by this change. Would really appreciate to look at it people who have such experience.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
