### PR TITLE
use config.base also in production

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,6 +131,7 @@ cli.command('build [root]', 'build for production').action(async (root: string, 
 
   try {
     await build(inlineConfig)
+    process.exit(0)
   } catch (e) {
     const error = e as Error
     createLogger(options.logLevel).error(colors.red(`error during build:\n${error.stack}`), { error })

--- a/src/plugins/electron.ts
+++ b/src/plugins/electron.ts
@@ -335,8 +335,7 @@ export function electronRendererVitePlugin(options?: ElectronPluginOptions): Plu
       config(config): void {
         const root = options?.root || process.cwd()
 
-        config.base =
-          config.mode === 'production' || process.env.NODE_ENV_ELECTRON_VITE === 'production' ? './' : config.base
+        config.base = config.base ?? './'
         config.root = config.root || './src/renderer'
 
         const chromeTarget = getElectronChromeTarget()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Instead of forcing a base of './' in production it now allows the user to decide via config.
Fixes #466

### Additional context

This is needed for example for prerendering in preact where each route has its own html file

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
