### PR TITLE
fix: don't handle file ids that begin with a null byte

### DIFF
--- a/src/plugins/asset.ts
+++ b/src/plugins/asset.ts
@@ -87,6 +87,12 @@ export default function assetPlugin(): Plugin {
         return wasmHelperCode
       }
 
+      if (id.startsWith('\0')) {
+        // Rollup convention, this id should be handled by the
+        // plugin that marked it with \0
+        return
+      }
+
       const assetResolved = resolveAsset(id)
       if (!assetResolved) {
         return


### PR DESCRIPTION
### Description

Rollup has a convention of prefixing some paths with a null byte (`\0`). Most plugins should just ignore files prefixed with the null byte, and this PR adds the proper handling to the electron-vite asset plugin.


### Additional context

This bug is seen in issues like #524 where there's an error:

```
[vite:node-asset] Could not load C:/Users/krystian/Desktop/test/main/node_modules/test-module/build/package/module.node?commonjs-proxy (imported by main/node_modules/test-module/index.js): The argument 'path' must be a string or Uint8Array without null bytes. Received '\\x00C:/Users/krystian/Desktop/test/main/node_modules/test-module/build/package/module.node'
TypeError [PLUGIN_ERROR]: Could not load C:/Users/krystian/Desktop/test/main/node_modules/test-module/build/package/module.node?commonjs-proxy (imported by main/node_modules/test-module/index.js): The argument 'path' must be a string or Uint8Array without null bytes. Received '\\x00C:/Users/krystian/Desktop/test/main/node_modules/test-module/build/package/module.node'
    at open (node:internal/fs/promises:586:10)
    at Object.readFile (node:internal/fs/promises:1025:20)
    at Object.load (file:///C:/Users/krystian/Desktop/test/node_modules/electron-vite/dist/chunks/lib-iT7MOERj.mjs:634:47)
    at Object.handler (file:///C:/Users/krystian/Desktop/test/node_modules/vite/dist/node/chunks/dep-BKbDVx1T.js:68900:19)
    at file:///C:/Users/krystian/Desktop/test/node_modules/rollup/dist/es/shared/node-entry.js:19774:40
    at async PluginDriver.hookFirstAndGetPlugin (file:///C:/Users/krystian/Desktop/test/node_modules/rollup/dist/es/shared/node-entry.js:19674:28)
    at async file:///C:/Users/krystian/Desktop/test/node_modules/rollup/dist/es/shared/node-entry.js:18845:33
    at async Queue.work (file:///C:/Users/krystian/Desktop/test/node_modules/rollup/dist/es/shared/node-entry.js:19884:32)

```

As noted in Rollups "conventions" page:
> If your plugin uses 'virtual modules' (e.g. for helper functions), prefix the module ID with \0. This prevents other plugins from trying to process it.

![image](https://github.com/alex8088/electron-vite/assets/4761903/15e6b2c7-9487-4178-9e59-b012d71cb840)

https://rollupjs.org/plugin-development/#conventions

In this case, the electron-vite plugin is not using virtual modules, but if other plugins are using it, electron-vite should not try to process the file.

Similar handling is done in vite's built-in asset plugin:

https://github.com/vitejs/vite/blob/a826a08736075049842c8addff66fe385008572a/packages/vite/src/node/plugins/asset.ts#L173-L182



### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
