### PR TITLE
fix: not using the mode from the config file

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,7 @@ export async function resolveConfig(
 
       if (loadResult.config.main) {
         const mainViteConfig: ViteConfig = mergeConfig(loadResult.config.main, deepClone(config))
+        mainViteConfig.mode = inlineConfig.mode || loadResult.config.main.mode || defaultMode
 
         if (outDir) {
           resetOutDir(mainViteConfig, outDir, 'main')
@@ -161,6 +162,7 @@ export async function resolveConfig(
 
       if (loadResult.config.preload) {
         const preloadViteConfig: ViteConfig = mergeConfig(loadResult.config.preload, deepClone(config))
+        preloadViteConfig.mode = inlineConfig.mode || loadResult.config.preload.mode || defaultMode
 
         if (outDir) {
           resetOutDir(preloadViteConfig, outDir, 'preload')
@@ -178,6 +180,7 @@ export async function resolveConfig(
 
       if (loadResult.config.renderer) {
         const rendererViteConfig: ViteConfig = mergeConfig(loadResult.config.renderer, deepClone(config))
+        rendererViteConfig.mode = inlineConfig.mode || loadResult.config.renderer.mode || defaultMode
 
         if (outDir) {
           resetOutDir(rendererViteConfig, outDir, 'renderer')


### PR DESCRIPTION
### Description

As described in [#531](https://github.com/alex8088/electron-vite/issues/531) electron-vite does not take into account the mode entered from the configuration file. This PR fixes this issue.

### Additional context

Following the documentation, the mode is taken first from `--mode` and then from the configuration, and the default is determined by the command.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
