### PR TITLE
fix(pnpm): support pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,5 +101,10 @@
     "esbuild": "^0.21.5",
     "magic-string": "^0.30.10",
     "picocolors": "^1.0.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "electron"
+    ]
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

pnpm 10 requires a "onlyBuiltDependencies" for electron's postinstall script to run.

Fixes: https://github.com/alex8088/electron-vite/issues/695

