### PR TITLE
fix: pass signals to electron process

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -161,5 +161,13 @@ export function startElectron(root: string | undefined): ChildProcess {
   const ps = spawn(electronPath, [entry].concat(args), { stdio: 'inherit' })
   ps.on('close', process.exit)
 
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGUSR2'] as NodeJS.Signals[]) {
+    process.on(signal, () => {
+      if (!ps.killed) {
+        ps.kill(signal)
+      }
+    })
+  }
+
   return ps
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Passes signals to electron process for cleaner exit.

### Additional context

Matches behavior of electron start script:
https://github.com/electron/electron/blob/31bc5ca903b35016649727326bf443ef11cc6e62/script/start.js#L10-L19

Before:
![image](https://github.com/user-attachments/assets/f9e78444-4ef2-494a-b977-a5b3abb7d8db)

After:
![image](https://github.com/user-attachments/assets/430eacba-415f-467d-957b-a2c4fd15d1eb)


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
