### PR TITLE
feat(preload): support bundling multiple preload scripts without requiring `sandbox: false`

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,5 +1,5 @@
 import { build as viteBuild } from 'vite'
-import { type InlineConfig, resolveConfig } from './config'
+import { type InlineConfig, resolveConfig, type InlineUserConfig } from './config'
 
 /**
  * Bundles the electron app for production.
@@ -10,24 +10,26 @@ export async function build(inlineConfig: InlineConfig = {}): Promise<void> {
   if (config.config) {
     const mainViteConfig = config.config?.main
     if (mainViteConfig) {
-      if (mainViteConfig.build?.watch) {
-        mainViteConfig.build.watch = null
-      }
-      await viteBuild(mainViteConfig)
+      await _build(mainViteConfig)
     }
     const preloadViteConfig = config.config?.preload
     if (preloadViteConfig) {
-      if (preloadViteConfig.build?.watch) {
-        preloadViteConfig.build.watch = null
+      if (Array.isArray(preloadViteConfig)) {
+        await Promise.all(preloadViteConfig.map(_build))
+      } else {
+        await _build(preloadViteConfig)
       }
-      await viteBuild(preloadViteConfig)
     }
     const rendererViteConfig = config.config?.renderer
     if (rendererViteConfig) {
-      if (rendererViteConfig.build?.watch) {
-        rendererViteConfig.build.watch = null
-      }
-      await viteBuild(rendererViteConfig)
+      _build(rendererViteConfig)
     }
   }
+}
+
+async function _build(config: InlineUserConfig): Promise<void> {
+  if (config.build?.watch) {
+    config.build.watch = null
+  }
+  await viteBuild(config)
 }


### PR DESCRIPTION
### Description

resolves https://github.com/alex8088/electron-vite/issues/812

This PR adds support for bundling multiple preload scripts without requiring `sandbox: false`. See the issue above for more details. ❤️

### Additional context

I'd also like to backport this feature to older versions if needed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
