### PR TITLE
fix: add negative lookbehind for comment in static import regex

### DIFF
--- a/src/plugins/esm.ts
+++ b/src/plugins/esm.ts
@@ -31,7 +31,7 @@ const require = __cjs_mod__.createRequire(import.meta.url);
 `
 
 const ESMStaticImportRe =
-  /(?<!\/\/.*?)(?<=\s|^|;)import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu
+  /(?<=^(|\s|;))import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu
 
 interface StaticImport {
   end: number


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The static import regex is missing an exclusion for the case where the import statement is a comment. The esm shim will be added below the comment instead of the actual last import statement in this case. I didn't spend much time on the regex edit, so if there's a better implementation, please make any suggestions for improvements!

Changed the regex to ensure start of line`(?<=^(|\s|;))`. Not sure if this is valid for all cases. For example, an invalid case where you have a space before the semicolon:
```javascript
// whitespace at start of line
 ;import __cjs_url__ from 'node:url';
```

An alternative is using a negative lookbehind for `//` (`(?<!\/\/.*?)`) which can be seen in the first commit:
```diff
const ESMStaticImportRe =
-  /(?<=\s|^|;)import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu
const ESMStaticImportRe =
+  /(?<!\/\/.*?)(?<=\s|^|;)import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu
```

### Additional context

I ran into this issue where it added the esm shim under the comment below instead. I didn't test thoroughly but it seems like the esm shim plugin runs before comments are removed in the build process.

Example:

```javascript
// import { $ZodType } from "./schemas.js";
// esm shim would be added here
const $ZodCheck = /*@__PURE__*/ $constructor("$ZodCheck", (inst, def) => {
    var _a;
    inst._zod ?? (inst._zod = {});
    inst._zod.def = def;
    (_a = inst._zod).onattach ?? (_a.onattach = []);
});
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
