### PR TITLE
feat: make options parameter in createServer optional

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { startElectron } from './electron'
 
 export async function createServer(
   inlineConfig: InlineConfig = {},
-  options: { rendererOnly?: boolean }
+  options: { rendererOnly?: boolean } = {}
 ): Promise<void> {
   process.env.NODE_ENV_ELECTRON_VITE = 'development'
   const config = await resolveConfig(inlineConfig, 'serve', 'development')


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

Make the `options` parameter in `createServer` optional by adding a default value.  
This allows calling `createServer()` without explicitly passing `{}`.

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
