### PR TITLE
feat: support custom Electron package name

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,13 @@ export interface RendererViteConfig extends BaseViteConfig<RendererBuildOptions>
 
 export interface UserConfig {
   /**
+   * Custom Electron package name (e.g., '@overwolf/ow-electron').
+   * Can also be set via ELECTRON_PKG_NAME environment variable.
+   *
+   * @default 'electron'
+   */
+  electronPackage?: string
+  /**
    * Vite config options for electron main process
    *
    * @see https://vitejs.dev/config/
@@ -310,6 +317,16 @@ export async function resolveConfig(
       userConfig = loadResult.config
       configFile = loadResult.path
       configFileDependencies = loadResult.dependencies
+    }
+  }
+
+  // Set ELECTRON_PKG_NAME from config or environment variable
+  // Priority: existing env var > config file > default to 'electron'
+  if (!process.env.ELECTRON_PKG_NAME) {
+    if (userConfig?.electronPackage) {
+      process.env.ELECTRON_PKG_NAME = userConfig.electronPackage
+    } else {
+      process.env.ELECTRON_PKG_NAME = 'electron'
     }
   }
 

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -6,6 +6,10 @@ import { loadPackageData } from './utils'
 
 const _require = createRequire(import.meta.url)
 
+const getElectronPackageName = (): string => {
+  return process.env.ELECTRON_PKG_NAME || 'electron'
+}
+
 const ensureElectronEntryFile = (root = process.cwd()): void => {
   if (process.env.ELECTRON_ENTRY) return
   const pkg = loadPackageData()
@@ -26,7 +30,8 @@ const ensureElectronEntryFile = (root = process.cwd()): void => {
 const getElectronMajorVer = (): string => {
   let majorVer = process.env.ELECTRON_MAJOR_VER || ''
   if (!majorVer) {
-    const pkg = _require.resolve('electron/package.json')
+    const electronPkgName = getElectronPackageName()
+    const pkg = _require.resolve(`${electronPkgName}/package.json`)
     if (fs.existsSync(pkg)) {
       const version = _require(pkg).version
       majorVer = version.split('.')[0]
@@ -49,7 +54,8 @@ export function supportImportMetaPaths(): boolean {
 export function getElectronPath(): string {
   let electronExecPath = process.env.ELECTRON_EXEC_PATH || ''
   if (!electronExecPath) {
-    const electronModulePath = path.dirname(_require.resolve('electron'))
+    const electronPkgName = getElectronPackageName()
+    const electronModulePath = path.dirname(_require.resolve(electronPkgName))
     const pathFile = path.join(electronModulePath, 'path.txt')
     let executablePath
     if (fs.existsSync(pathFile)) {
@@ -59,7 +65,7 @@ export function getElectronPath(): string {
       electronExecPath = path.join(electronModulePath, 'dist', executablePath)
       process.env.ELECTRON_EXEC_PATH = electronExecPath
     } else {
-      throw new Error('Electron uninstall')
+      throw new Error(`Electron package "${electronPkgName}" not found or uninstalled`)
     }
   }
   return electronExecPath


### PR DESCRIPTION
### Description

This PR allows the use of a custom package name to substitute the default `electron` package that is invoked. Several forks of Electron, including [Overwolf's custom one](https://overwolf.github.io/tools/ow-electron), change the package identifier therefor not working out of the box with this plugin. Instead of invoking `electron`, I wish to invoke `@overwolf/ow-electron`.

This concept was also implemented on a previous vite-based electron tooling I used: https://github.com/electron-vite/vite-plugin-electron/pull/229

### Additional context

N/A

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
