### PR TITLE
feat(bytecode): support RegExp for chunkAlias option

### DIFF
--- a/src/plugins/bytecode.ts
+++ b/src/plugins/bytecode.ts
@@ -143,7 +143,7 @@ const bytecodeModuleLoaderCode = [
 const bytecodeChunkExtensionRE = /.(jsc|cjsc)$/
 
 export interface BytecodeOptions {
-  chunkAlias?: string | string[]
+  chunkAlias?: string | string[] | RegExp
   transformArrowFunctions?: boolean
   removeBundleJS?: boolean
   protectedStrings?: string[]
@@ -160,11 +160,13 @@ export function bytecodePlugin(options: BytecodeOptions = {}): Plugin | null {
   }
 
   const { chunkAlias = [], transformArrowFunctions = true, removeBundleJS = true, protectedStrings = [] } = options
-  const _chunkAlias = Array.isArray(chunkAlias) ? chunkAlias : [chunkAlias]
+  const _chunkAlias = chunkAlias instanceof RegExp ? chunkAlias : Array.isArray(chunkAlias) ? chunkAlias : [chunkAlias]
 
-  const transformAllChunks = _chunkAlias.length === 0
   const isBytecodeChunk = (chunkName: string): boolean => {
-    return transformAllChunks || _chunkAlias.some(alias => alias === chunkName)
+    if (_chunkAlias instanceof RegExp) {
+      return _chunkAlias.test(chunkName)
+    }
+    return _chunkAlias.length === 0 || _chunkAlias.some(alias => alias === chunkName)
   }
 
   const plugins: babel.PluginItem[] = []


### PR DESCRIPTION
### Description

Add `RegExp` support for `BytecodeOptions.chunkAlias` to allow pattern-based chunk matching.

Currently, `chunkAlias` only accepts `string | string[]`, requiring exact chunk name matches. This change adds `RegExp` as an accepted type, enabling flexible pattern matching via `RegExp.prototype.test()`.

**Changes:**
- Add `RegExp` to the `chunkAlias` type definition in `BytecodeOptions`
- Update `_chunkAlias` initialization to handle `RegExp` type
- Update `isBytecodeChunk` to use `RegExp.test()` when a regex is provided

### Additional context

This is useful when chunk names follow a naming convention and users want to match multiple chunks without listing each name explicitly.

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/alex8088/electron-vite/blob/master/CONTRIBUTING.md#pull-request) and follow the [Commit Convention](https://github.com/alex8088/electron-vite/blob/master/.github/commit-convention.md).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).