### PR TITLE
fix(isolateEntries): handle non-TTY stdout in build reporter

### DIFF
--- a/src/plugins/isolateEntries.ts
+++ b/src/plugins/isolateEntries.ts
@@ -170,6 +170,7 @@ function transformReporterPlugin(
 }
 
 function writeLine(output: string): void {
+  if (!process.stdout.isTTY) return
   clearLine()
   if (output.length < process.stdout.columns) {
     process.stdout.write(output)
@@ -179,6 +180,7 @@ function writeLine(output: string): void {
 }
 
 function clearLine(move: number = 0): void {
+  if (!process.stdout.isTTY) return
   if (move < 0) {
     process.stdout.moveCursor(0, move)
   }


### PR DESCRIPTION
## Summary

- The `clearLine` and `writeLine` helpers in `isolateEntries.ts` use TTY-only methods (`clearLine`, `cursorTo`, `moveCursor`) without checking `process.stdout.isTTY`, causing builds to crash in non-interactive environments like CI or piped output.
- Added `if (!process.stdout.isTTY) return` early-exit guards to both functions, consistent with how Vite's own built-in reporter handles this.

See error I got in my CI environment:

```
vite v7.3.1 building ssr environment for production...
✗ Build failed in 7ms
✓ 0 modules transformed.
✗ Build failed in 9ms
error during build:
[vite:isolate-entries] Could not load virtual:isolate-entries:
  [vite:transform-reporter] process.stdout.clearLine is not a function
```

## Reproduction

1. Enable `isolateEntries` in your config


2.

```bash
# Any of these reproduce the crash:
electron-vite build | cat
electron-vite build > build.log 2>&1
# Or run in GitHub Actions CI
```