### PR TITLE
[WIP] feat: add Vite 8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "@swc/core": "^1.0.0",
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "@swc/core": {

--- a/src/plugins/importMeta.ts
+++ b/src/plugins/importMeta.ts
@@ -1,10 +1,17 @@
+import MagicString from 'magic-string'
+import type { SourceMapInput } from 'rollup'
 import type { Plugin } from 'vite'
+
+const importMetaUrlRE = /\bimport\.meta\.url\b/g
+const importMetaFilenameRE = /\bimport\.meta\.filename\b/g
+const importMetaDirnameRE = /\bimport\.meta\.dirname\b/g
 
 export default function importMetaPlugin(): Plugin {
   return {
     name: 'vite:import-meta',
     apply: 'build',
     enforce: 'pre',
+    // For Vite 5-7 (Rollup) - this hook is removed in Vite 8
     resolveImportMeta(property, { format }): string | null {
       if (property === 'url' && format === 'cjs') {
         return `require("url").pathToFileURL(__filename).href`
@@ -16,6 +23,34 @@ export default function importMetaPlugin(): Plugin {
         return `__dirname`
       }
       return null
+    },
+    // Fallback for Vite 8+ (Rolldown) where resolveImportMeta is removed
+    renderChunk(code, _chunk, { format, sourcemap }): { code: string; map?: SourceMapInput } | null {
+      if (format !== 'cjs') return null
+      if (!code.includes('import.meta.')) return null
+
+      const s = new MagicString(code)
+      let hasReplacements = false
+
+      for (const match of code.matchAll(importMetaUrlRE)) {
+        s.overwrite(match.index, match.index + match[0].length, 'require("url").pathToFileURL(__filename).href')
+        hasReplacements = true
+      }
+      for (const match of code.matchAll(importMetaFilenameRE)) {
+        s.overwrite(match.index, match.index + match[0].length, '__filename')
+        hasReplacements = true
+      }
+      for (const match of code.matchAll(importMetaDirnameRE)) {
+        s.overwrite(match.index, match.index + match[0].length, '__dirname')
+        hasReplacements = true
+      }
+
+      if (!hasReplacements) return null
+
+      return {
+        code: s.toString(),
+        map: sourcemap ? s.generateMap({ hires: 'boundary' }) : null
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `^8.0.0` to the `vite` peer dependency range
- Add `renderChunk` fallback in the `importMeta` plugin for Vite 8, where the `resolveImportMeta` Rollup hook has been removed (Rolldown replaces Rollup)
- Existing `resolveImportMeta` hook is preserved for Vite 5-7 backward compatibility

## Details

Vite 8 replaces Rollup with Rolldown, which removes several Rollup-specific hooks including `resolveImportMeta`. The importMeta plugin relied on this hook to rewrite `import.meta.url`, `import.meta.filename`, and `import.meta.dirname` to their CJS equivalents (`__filename`, `__dirname`, `require("url").pathToFileURL(__filename).href`) when building for CJS format.

The new `renderChunk` fallback performs regex-based string replacement on CJS output chunks. On Vite 5-7, `resolveImportMeta` handles the rewriting during Rollup's output generation phase, so the `renderChunk` fallback finds nothing to replace. On Vite 8+, `resolveImportMeta` is ignored and `renderChunk` catches any remaining `import.meta.*` references.

The `build.rollupOptions` config used throughout the codebase is deprecated in Vite 8 (in favor of `build.rolldownOptions`) but remains functional, so no changes are needed there for now.

## Test plan
- [ ] Verify `electron-vite build` works with Vite 5, 6, 7 (no regressions)
- [ ] Verify `electron-vite build` works with Vite 8
- [ ] Verify `import.meta.url`, `import.meta.filename`, `import.meta.dirname` are correctly rewritten in CJS main/preload builds on all supported Vite versions
- [ ] Verify TypeScript type-checking passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)