### PR TITLE
fix(dev): forward termination signals to Electron child (#899)

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -161,5 +161,32 @@ export function startElectron(root: string | undefined): ChildProcess {
   const ps = spawn(electronPath, [entry].concat(args), { stdio: 'inherit' })
   ps.on('close', process.exit)
 
+  forwardTerminationSignals(ps)
+
   return ps
+}
+
+let signalHandlersInstalled = false
+let currentElectronPs: ChildProcess | undefined
+
+// Forward termination signals to the Electron child, matching electron's own
+// CLI wrapper (node_modules/electron/cli.js). Without this, Ctrl-C kills the
+// parent immediately and the Electron child can get stuck on macOS when a
+// before-quit handler calls preventDefault then later app.quit(). See #899.
+function forwardTerminationSignals(ps: ChildProcess): void {
+  currentElectronPs = ps
+  if (signalHandlersInstalled) return
+  signalHandlersInstalled = true
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+    process.on(signal, () => {
+      const target = currentElectronPs
+      if (target && target.exitCode === null && !target.killed) {
+        try {
+          target.kill(signal)
+        } catch {
+          // already gone
+        }
+      }
+    })
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #899. In `startElectron`, forward `SIGINT`/`SIGTERM`/`SIGHUP` from the electron-vite parent to the spawned Electron child, matching Electron's own CLI wrapper (`node_modules/electron/cli.js`).

## Why

electron-vite spawns the Electron binary directly via `spawn(electronPath, ...)` and does not trap signals. When the user hits Ctrl-C in a dev session:

- SIGINT is delivered to the foreground process group **once**.
- The Node parent has no SIGINT handler, so it exits immediately with Node's default behavior.
- The Electron child receives only that single SIGINT.

Under a direct `./node_modules/.bin/electron .` launch the picture is different: the Electron CLI shim installs a handler that forwards SIGINT to its child, so the Electron child receives SIGINT **twice** (once from the pgroup, once forwarded). On macOS, an Electron app whose `before-quit` handler calls `event.preventDefault()` and then later calls `app.quit()` from an async continuation can stall in AppKit's event loop — never reaching `[NSApp terminate:]`. The second SIGINT forwarded by the shim is what knocks Electron out of that stuck state.

By matching that forwarding behavior in `electron-vite`, `electron-vite dev` now exits as cleanly as `electron .` does for that app.

A reduced test was run against the repro in the issue (https://github.com/iddogino/electron-vite-quit-repro):

| scenario | result |
|---|---|
| unpatched, Ctrl-C via pty | hangs — 3 Electron processes lingering |
| parent kept alive but no forwarding | still hangs |
| parent kept alive **and** signal forwarded (this PR) | clean exit, 0 lingering |

## Notes on the implementation

- `currentElectronPs` tracks the latest-spawned child so that when the watch-on-rebuild path (`server.ts`) kills the old Electron and spawns a new one, signals go to the current child, not a stale reference.
- `signalHandlersInstalled` guards against accumulating `process.on` handlers across dev restarts.
- The `ps.on('close', process.exit)` behavior is unchanged, so a normal in-app quit still exits the parent as before.

## Test plan

- [x] `pnpm run lint`, `pnpm run typecheck`, `pnpm run build` all pass.
- [x] `prettier --check src/electron.ts` passes.
- [x] Built `dist` dropped into the repro — pty Ctrl-C exits cleanly (0 lingering Electron processes).
- [x] Manual sanity test on the repro in a real terminal with Ctrl-C.
- [x] Manual sanity test of the watch-restart path (edit `src/main/index.js`, confirm restart still works).