### PR TITLE
feat: support electron 42

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@
 npm i electron-vite -D
 ```
 
+> **Note:** Starting with [Electron 42](https://www.electronjs.org/blog/electron-42-0), the `electron` package no longer downloads its binary via `postinstall`. You do not need to add an `install-electron` postinstall script — `electron-vite` will download the binary on demand the first time you run `dev`, `build`, or `preview`, mirroring the behavior of `npx electron`.
+
 ### Development & Build
 
 In a project where `electron-vite` is installed, you can use `electron-vite` binary directly with `npx electron-vite` or add the npm scripts to your `package.json` file like this:

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -1,7 +1,9 @@
 import path from 'node:path'
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
-import { type ChildProcess, spawn } from 'node:child_process'
+import { type ChildProcess, spawn, spawnSync } from 'node:child_process'
+import colors from 'picocolors'
+import { createLogger } from 'vite'
 import { loadPackageData } from './utils'
 
 const _require = createRequire(import.meta.url)
@@ -46,20 +48,39 @@ export function supportImportMetaPaths(): boolean {
   return parseInt(majorVer) >= 30
 }
 
+function installElectronBinary(electronModulePath: string): void {
+  const installScript = path.join(electronModulePath, 'install.js')
+  if (!fs.existsSync(installScript)) {
+    throw new Error(`electron install script not found at ${installScript}, please reinstall the electron package`)
+  }
+  createLogger().info(colors.green('Electron binary not found, installing...'))
+  const result = spawnSync(process.execPath, [installScript], {
+    stdio: 'inherit',
+    cwd: electronModulePath
+  })
+  if (result.status !== 0) {
+    throw new Error('Failed to install electron binary')
+  }
+}
+
 export function getElectronPath(): string {
   let electronExecPath = process.env.ELECTRON_EXEC_PATH || ''
   if (!electronExecPath) {
     const electronModulePath = path.dirname(_require.resolve('electron'))
     const pathFile = path.join(electronModulePath, 'path.txt')
-    let executablePath
-    if (fs.existsSync(pathFile)) {
-      executablePath = fs.readFileSync(pathFile, 'utf-8')
+    const readPathFile = (): string | undefined =>
+      fs.existsSync(pathFile) ? fs.readFileSync(pathFile, 'utf-8') : undefined
+    let executablePath = readPathFile()
+    if (!executablePath && parseInt(getElectronMajorVer()) >= 42) {
+      // Electron 42+ no longer downloads its binary via postinstall (supply-chain hardening).
+      installElectronBinary(electronModulePath)
+      executablePath = readPathFile()
     }
     if (executablePath) {
       electronExecPath = path.join(electronModulePath, 'dist', executablePath)
       process.env.ELECTRON_EXEC_PATH = electronExecPath
     } else {
-      throw new Error('Electron uninstall')
+      throw new Error('Electron is not installed')
     }
   }
   return electronExecPath
@@ -69,6 +90,7 @@ export function getElectronNodeTarget(): string {
   const electronVer = getElectronMajorVer()
 
   const nodeVer = {
+    '42': '24.15',
     '41': '24.14',
     '40': '24.14',
     '39': '22.20',
@@ -102,6 +124,7 @@ export function getElectronChromeTarget(): string {
   const electronVer = getElectronMajorVer()
 
   const chromeVer = {
+    '42': '148',
     '41': '146',
     '40': '144',
     '39': '142',


### PR DESCRIPTION
## Summary

- Add Electron 42 to the `nodeVer` / `chromeVer` build target tables in `src/electron.ts` (Chromium 148 / Node 24.15, per the [Electron 42 release notes](https://www.electronjs.org/blog/electron-42-0)).
- Lazily run `node_modules/electron/install.js` from `getElectronPath()` when `path.txt` is missing **and** the resolved Electron major version is ≥ 42. Electron 42 [removed the postinstall download](https://www.electronjs.org/blog/electron-42-0) for supply-chain hardening, so without this fix users hit `Electron uninstall` on `electron-vite dev / build / preview`.
- The lazy-install behavior mirrors `npx electron`, so users do **not** need to add a manual `install-electron` postinstall script to `package.json`.
- Tighten the related error messages: `'Electron uninstall'` → `'Electron is not installed'`, and surface a specific error if `install.js` itself is missing from the electron package.
- Add a short note in the README pointing at the Electron 42 blog post.

Closes #904

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] Manual: in a clean workspace, `pnpm i electron@42 && pnpm exec electron-vite dev` triggers the install script on first run, populates `node_modules/electron/path.txt`, and launches the app.
- [ ] Manual: with Electron < 42 installed, behavior is unchanged (no install attempt; existing `path.txt` flow).
- [ ] Manual: with `ELECTRON_SKIP_BINARY_DOWNLOAD=1` previously set on Electron < 42, behavior is unchanged.

## Notes

- For Electron < 42 we deliberately do **not** auto-run `install.js`, to preserve the behavior of users who opted out via `ELECTRON_SKIP_BINARY_DOWNLOAD`.
- `getElectronPath()` is called from both `startElectron()` (dev/preview) and the bytecode plugin (build), so the lazy install covers all entry points.