### PR TITLE
fix(esm-shim): ignore import-like text inside strings/comments

### DIFF
--- a/src/plugins/esmShim.ts
+++ b/src/plugins/esmShim.ts
@@ -37,12 +37,106 @@ interface StaticImport {
   end: number
 }
 
+/**
+ * Replace string/template contents and comments with spaces of the same length.
+ * Indices stay aligned with the original source so import-end offsets still apply
+ * when injecting the CJS shim.
+ *
+ * Without this, `import ... from '...'` text embedded in string literals (common
+ * in large app bundles that ship schema/SQL/source snippets) is treated as a real
+ * static import. Injecting the shim after that false match mid-string corrupts
+ * the chunk and can cause bundlers (e.g. Rolldown / Vite 8) to emit an empty entry
+ * — see https://github.com/alex8088/electron-vite/issues/906
+ */
+export function maskNonCode(code: string): string {
+  let out = ''
+  let i = 0
+  const n = code.length
+  const spaces = (len: number): string => ' '.repeat(len)
+
+  while (i < n) {
+    const c = code[i]!
+    const c2 = code[i + 1]
+
+    // line comment
+    if (c === '/' && c2 === '/') {
+      let j = i + 2
+      while (j < n && code[j] !== '\n' && code[j] !== '\r') j++
+      out += spaces(j - i)
+      i = j
+      continue
+    }
+
+    // block comment
+    if (c === '/' && c2 === '*') {
+      let j = i + 2
+      while (j + 1 < n && !(code[j] === '*' && code[j + 1] === '/')) j++
+      j = Math.min(j + 2, n)
+      out += spaces(j - i)
+      i = j
+      continue
+    }
+
+    // single- and double-quoted strings
+    if (c === '"' || c === "'") {
+      const q = c
+      let j = i + 1
+      while (j < n) {
+        if (code[j] === '\\') {
+          j += 2
+          continue
+        }
+        if (code[j] === q) {
+          j++
+          break
+        }
+        j++
+      }
+      out += spaces(j - i)
+      i = j
+      continue
+    }
+
+    // template literals (mask whole span, including ${...} expressions —
+    // rare real top-level imports inside interpolations, and safer than
+    // re-matching import-like SQL/source embedded in templates)
+    if (c === '`') {
+      let j = i + 1
+      while (j < n) {
+        if (code[j] === '\\') {
+          j += 2
+          continue
+        }
+        if (code[j] === '`') {
+          j++
+          break
+        }
+        j++
+      }
+      out += spaces(j - i)
+      i = j
+      continue
+    }
+
+    out += c
+    i++
+  }
+
+  return out
+}
+
 function findStaticImports(code: string): StaticImport[] {
+  const searchable = maskNonCode(code)
   const matches: StaticImport[] = []
-  for (const match of code.matchAll(ESMStaticImportRe)) {
+  for (const match of searchable.matchAll(ESMStaticImportRe)) {
     matches.push({ end: (match.index || 0) + match[0].length })
   }
   return matches
+}
+
+function hasCjsSyntax(code: string): boolean {
+  // Ignore CJS markers that only appear inside strings/comments
+  return CJSyntaxRe.test(maskNonCode(code))
 }
 
 export default function esmShimPlugin(): Plugin {
@@ -54,7 +148,7 @@ export default function esmShimPlugin(): Plugin {
     enforce: 'post',
     renderChunk(code, _chunk, { format, sourcemap }): { code: string; map?: SourceMapInput } | null {
       if (format === 'es') {
-        if (code.includes(CJSShim) || !CJSyntaxRe.test(code)) {
+        if (code.includes(CJSShim) || !hasCjsSyntax(code)) {
           return null
         }
 

--- a/src/plugins/swc.ts
+++ b/src/plugins/swc.ts
@@ -83,8 +83,12 @@ export function swcPlugin(options: SwcOptions = {}): Plugin {
   return {
     name: 'vite:swc',
     config(): UserConfig {
+      // Vite 8 moved default transform to Oxc: only disabling esbuild is ignored
+      // and emits a warning. SWC replaces both paths when this plugin is active.
+      // See https://github.com/alex8088/electron-vite/issues/916
       return {
-        esbuild: false
+        esbuild: false,
+        oxc: false
       }
     },
     async configResolved(resolvedConfig): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes empty ESM main-entry emission under Vite 8 / Rolldown when `vite:esm-shim` injects the CJS shim after a false “static import” match inside string/template payload.

### What changed

- **`vite:esm-shim`**: mask string, template, and comment spans (same length → original indexes stay valid) before:
  - detecting CJS syntax (`__dirname` / `require(…)`), and
  - finding the last static `import` for shim insertion
- **`swcPlugin`**: set `oxc: false` alongside `esbuild: false` so Vite 8 does not ignore the disable and warn that only Oxc must be turned off

### Why

Large main bundles often embed schema/SQL/source text such as:

```ts
import {XxxModel, XxxOption} from './XxxModel.js';
```

The previous regex scanned the raw rendered chunk, treated those as real top-level imports, and injected the shim mid-string → corrupted chunk → Rolldown could emit `dist/main/index.js` as **0.00 kB**.

Reported detail and instrumentation in #906. #916 is the Vite 8 SWC transform warning.

## Related issues

Closes #906  
Closes #916

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`

## Checklist

- [x] Focused change, no unrelated reformat
- [x] Commit follows repo commit convention


Made with [Cursor](https://cursor.com)