### PR TITLE
fix(swcPlugin): also disable oxc on Vite 8

### DIFF
--- a/src/plugins/swc.ts
+++ b/src/plugins/swc.ts
@@ -83,8 +83,12 @@ export function swcPlugin(options: SwcOptions = {}): Plugin {
   return {
     name: 'vite:swc',
     config(): UserConfig {
+      // Vite 8 defaults to Oxc for transform; `esbuild: false` is ignored and
+      // warns. SWC replaces both paths when this plugin is active.
+      // See https://github.com/alex8088/electron-vite/issues/916
       return {
-        esbuild: false
+        esbuild: false,
+        oxc: false
       }
     },
     async configResolved(resolvedConfig): Promise<void> {


### PR DESCRIPTION
## Summary
- Vite 8 moved the default transform path to Oxc. `swcPlugin` only set `esbuild: false`, which is ignored and prints the oxc warning (#916).
- Disable both `esbuild` and `oxc` when SWC is the transform for the plugin.

## Test plan
- [ ] `swcPlugin()` config no longer warns under Vite 8
- [ ] SWC still transforms TS/decorators as before
- [ ] CI on PR


Made with [Cursor](https://cursor.com)